### PR TITLE
Fix for Unique IP Assignment on Cloned VMs

### DIFF
--- a/tasks/customize-images.yaml
+++ b/tasks/customize-images.yaml
@@ -7,7 +7,7 @@
   when: installAgent | bool
 - name: add install agent
   ansible.builtin.shell: |
-    virt-customize -a {{ isopath }}/{{ item.templateName }}.qcow2 --install qemu-guest-agent 
+    virt-customize -a {{ isopath }}/{{ item.templateName }}.qcow2 --install qemu-guest-agent --truncate /etc/machine-id
   with_items: "{{ cloudimgs }}"
   when: installAgent | bool
   loop_control:


### PR DESCRIPTION
 A line has been added to `customize-images.yaml` to ensure each cloned VM gets a unique IP address. This was achieved by truncating the `machine-id` file in the VM image before it's templated.

Changes:
- Added a task in `customize-images.yaml` to execute `virt-customize` with `--truncate /etc/machine-id` option.
```yaml
ansible.builtin.command: |
    virt-customize -a {{ isopath }}/{{ item.templateName }}.qcow2 --install qemu-guest-agent --truncate /etc/machine-id
```

Outcome:

Successfully cloned the template multiple times, with each VM receiving a unique IP address as intended.
