### PR TITLE
3 unable to ssh in after template change

### DIFF
--- a/files/clear-machine-id.sh
+++ b/files/clear-machine-id.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Clear machine-id
+if [ -f /etc/machine-id ]; then
+    cat /dev/null > /etc/machine-id
+fi
+
+if [ -f /var/lib/dbus/machine-id ]; then
+    rm -f /var/lib/dbus/machine-id
+fi
+
+# Linking /var/lib/dbus/machine-id to /etc/machine-id
+ln -s /etc/machine-id /var/lib/dbus/machine-id

--- a/tasks/customize-images.yaml
+++ b/tasks/customize-images.yaml
@@ -7,9 +7,15 @@
   when: installAgent | bool
 - name: add install agent
   ansible.builtin.shell: |
-    virt-customize -a {{ isopath }}/{{ item.templateName }}.qcow2 --install qemu-guest-agent --truncate /etc/machine-id
+    virt-customize -a {{ isopath }}/{{ item.templateName }}.qcow2 --install qemu-guest-agent
   with_items: "{{ cloudimgs }}"
   when: installAgent | bool
+  loop_control:
+    extended: true
+- name: fix machine id
+  ansible.builtin.shell: |
+    virt-customize -a {{ isopath }}/{{ item.templateName }}.qcow2 --run {{ isopath }}/clear-machine-id.sh
+  with_items: "{{ cloudimgs }}"
   loop_control:
     extended: true
 - name: resize cloud-init images

--- a/tasks/download-images.yaml
+++ b/tasks/download-images.yaml
@@ -31,3 +31,8 @@
     url: "{{ item.url }}"
     dest: "{{ isopath }}/{{ item.templateName }}.qcow2"
   with_items: "{{ cloudimgs }}"
+- name: script tp clear machine id
+  ansible.builtin.copy:
+    src: clear-machine-id.sh
+    dest: "{{ isopath }}/clear-machine-id.sh"
+    mode: '0755'


### PR DESCRIPTION
Explained in issue #3 we are unable to ssh into machines after fixing the proxmox duplicate ip issues from the machine id, we are instead running a script to properly clear and link the machine ids